### PR TITLE
feat(frontend): Create Error message and Hint component.

### DIFF
--- a/src/components/ErrorText/ErrorText.stories.tsx
+++ b/src/components/ErrorText/ErrorText.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryFn } from '@storybook/react';
+
+import { ErrorText, ErrorTextProps } from './ErrorText';
+
+export default {
+  children: 'Error text',
+  component: ErrorText,
+} as Meta;
+
+const Template: StoryFn<ErrorTextProps> = (args) => <ErrorText {...args} />;
+
+export const defaultError = Template.bind({});
+defaultError.args = {
+  children: 'Error message',
+};
+
+export const CustomStyling = Template.bind({});
+CustomStyling.args = {
+  className: 'text-3xl',
+  children: 'Error message with large text',
+};
+
+export const ComplexChildren = Template.bind({});
+ComplexChildren.args = {
+  children: (
+    <div>
+      Error message with link{' '}
+      <a className="underline text-link" href="/">
+        Link
+      </a>
+    </div>
+  ),
+};

--- a/src/components/ErrorText/ErrorText.stories.tsx
+++ b/src/components/ErrorText/ErrorText.stories.tsx
@@ -9,8 +9,8 @@ export default {
 
 const Template: StoryFn<ErrorTextProps> = (args) => <ErrorText {...args} />;
 
-export const defaultError = Template.bind({});
-defaultError.args = {
+export const DefaultError = Template.bind({});
+DefaultError.args = {
   children: 'Error message',
 };
 

--- a/src/components/ErrorText/ErrorText.test.tsx
+++ b/src/components/ErrorText/ErrorText.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ErrorText } from './ErrorText';
+
+describe('ErrorText', () => {
+  it('renders with default ErrorText', () => {
+    render(<ErrorText>Error message</ErrorText>);
+
+    expect(screen.getByRole('paragraph')).toHaveTextContent(/error message/i);
+  });
+
+  it('renders with custom styles', () => {
+    render(<ErrorText className="bg-orange-500">Error text</ErrorText>);
+
+    const error = screen.getByRole('paragraph');
+
+    expect(error).toHaveClass(/bg-orange-500/i);
+    expect(error).not.toHaveClass(/bg-green-500/i);
+    expect(error).toHaveTextContent(/error text/i);
+  });
+
+  it('renders with complex children', () => {
+    render(
+      <ErrorText>
+        <a href="/">Error link</a>
+      </ErrorText>,
+    );
+
+    const linkElement = screen.getByRole('link', { name: /error link/i });
+
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', '/');
+  });
+});

--- a/src/components/ErrorText/ErrorText.tsx
+++ b/src/components/ErrorText/ErrorText.tsx
@@ -1,0 +1,13 @@
+import { twMerge } from 'tailwind-merge';
+
+import { ExtendProps } from '@/utils';
+
+export type ErrorTextProps = ExtendProps<'p'>;
+
+export const ErrorText = ({ className, children, ...props }: ErrorTextProps) => {
+  return (
+    <p className={twMerge('mb-3 text-base text-error font-bold', className)} {...props}>
+      {children}
+    </p>
+  );
+};

--- a/src/components/Hint/Hint.stories.tsx
+++ b/src/components/Hint/Hint.stories.tsx
@@ -1,0 +1,38 @@
+import { action } from '@storybook/addon-actions';
+import { Meta, StoryFn } from '@storybook/react';
+
+import { Hint, HintProps } from './Hint';
+import { Button } from '../Button/Button';
+
+export default {
+  children: 'Hint',
+  component: Hint,
+} as Meta;
+
+const Template: StoryFn<HintProps> = (args) => <Hint {...args} />;
+
+export const defaultHint = Template.bind({});
+defaultHint.args = {
+  children: 'Hint message',
+};
+
+export const CustomStyling = Template.bind({});
+CustomStyling.args = {
+  className: 'text-3xl',
+  children: 'Error message with extra large text',
+};
+
+export const ComplexChildren = Template.bind({});
+ComplexChildren.args = {
+  children: (
+    <div>
+      Hint message with link and button{' '}
+      <a className="underline text-link" href="/">
+        Link
+      </a>
+      <Button type="primary" onClick={action('primary-click')}>
+        Click
+      </Button>
+    </div>
+  ),
+};

--- a/src/components/Hint/Hint.stories.tsx
+++ b/src/components/Hint/Hint.stories.tsx
@@ -11,8 +11,8 @@ export default {
 
 const Template: StoryFn<HintProps> = (args) => <Hint {...args} />;
 
-export const defaultHint = Template.bind({});
-defaultHint.args = {
+export const DefaultHint = Template.bind({});
+DefaultHint.args = {
   children: 'Hint message',
 };
 

--- a/src/components/Hint/Hint.test.tsx
+++ b/src/components/Hint/Hint.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Hint } from './Hint';
+
+describe('Hint', () => {
+  it('renders with default Hint message', () => {
+    render(<Hint>Hint text</Hint>);
+    expect(screen.getByText(/hint text/i)).toHaveTextContent(/hint text/i);
+  });
+
+  it('renders with custom styles', () => {
+    render(<Hint className="bg-orange-500">hint message</Hint>);
+
+    const hintElement = screen.getByText(/hint message/i);
+
+    expect(hintElement).toHaveClass(/bg-orange-500/i);
+    expect(hintElement).not.toHaveClass(/bg-green-500/i);
+  });
+
+  it('renders with complex children', () => {
+    render(
+      <Hint>
+        Some description text <a href="/">Link</a>
+      </Hint>,
+    );
+
+    const linkElement = screen.getByRole('link', { name: /link/i });
+
+    expect(screen.getByText(/some description text/i)).toBeInTheDocument();
+
+    expect(linkElement).toBeInTheDocument();
+    expect(linkElement).toHaveAttribute('href', '/');
+  });
+});

--- a/src/components/Hint/Hint.tsx
+++ b/src/components/Hint/Hint.tsx
@@ -1,0 +1,21 @@
+import { twMerge } from 'tailwind-merge';
+
+import { ExtendProps } from '@/utils';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export type HintProps = ExtendProps<'div', Props>;
+
+export const Hint = ({ className, children, ...props }: HintProps) => {
+  return (
+    <p
+      aria-label="hint message"
+      className={twMerge('block mb-2 text-lg text-text-secondary', className)}
+      {...props}
+    >
+      {children}
+    </p>
+  );
+};

--- a/src/components/Hint/Hint.tsx
+++ b/src/components/Hint/Hint.tsx
@@ -2,20 +2,12 @@ import { twMerge } from 'tailwind-merge';
 
 import { ExtendProps } from '@/utils';
 
-type Props = {
-  children: React.ReactNode;
-};
-
-export type HintProps = ExtendProps<'div', Props>;
+export type HintProps = ExtendProps<'div'>;
 
 export const Hint = ({ className, children, ...props }: HintProps) => {
   return (
-    <p
-      aria-label="hint message"
-      className={twMerge('block mb-2 text-lg text-text-secondary', className)}
-      {...props}
-    >
+    <div className={twMerge('block mb-2 text-lg text-text-secondary', className)} {...props}>
       {children}
-    </p>
+    </div>
   );
 };

--- a/src/components/Hint/Hint.tsx
+++ b/src/components/Hint/Hint.tsx
@@ -6,7 +6,7 @@ export type HintProps = ExtendProps<'div'>;
 
 export const Hint = ({ className, children, ...props }: HintProps) => {
   return (
-    <div className={twMerge('block mb-2 text-lg text-text-secondary', className)} {...props}>
+    <div className={twMerge('mb-2 text-lg text-text-secondary', className)} {...props}>
       {children}
     </div>
   );


### PR DESCRIPTION
- I have created the Error message and Hint components.
- These components will accept custom styling and complex children render and also accept the all properties of the respective components elements.